### PR TITLE
fix(deps): bump bcpkix-jdk15on to bcpkix-jdk18on - resolves Dependabot Alert #7

### DIFF
--- a/sapl-demo-ethereum/pom.xml
+++ b/sapl-demo-ethereum/pom.xml
@@ -133,8 +133,8 @@
 		<!-- Argon2 -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.70</version>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>1.79</version>
 		</dependency>
 
 		<!-- Development Tools -->


### PR DESCRIPTION
This pull request addresses a vulnerability in bckpix-jdk15on] by upgrading to bcpkix-jdk18on], as reported in Dependabot Alert https://github.com/heutelbeck/sapl-policy-engine/pull/7 (https://github.com/advisories/GHSA-4cx2-fc23-5wg6).